### PR TITLE
fix: docker image pip install

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,6 +67,34 @@ stop-docker:
     #!/usr/bin/env bash
     docker stop whisper-server || true
 
+# Smoke test docker image
+smoke-test-docker port="9003":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build-docker
+    docker rm -f whisper-smoke 2>/dev/null || true
+    docker run -d --name whisper-smoke -p {{ port }}:9002 \
+        ghcr.io/paolino/whisper-server:latest
+    echo "Waiting for server to start..."
+    sleep 30
+    python3 -c "
+import asyncio
+import websockets
+import json
+
+async def test():
+    async with websockets.connect('ws://localhost:{{ port }}') as ws:
+        await ws.send(json.dumps({'eof': True}))
+        response = await ws.recv()
+        result = json.loads(response)
+        assert result['status'] == 0, f'Bad status: {result}'
+        assert result['result']['final'] == True, f'Not final: {result}'
+        print('SMOKE TEST PASSED')
+
+asyncio.run(test())
+"
+    docker rm -f whisper-smoke
+
 # Serve documentation locally
 serve-docs:
     #!/usr/bin/env bash

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -17,9 +17,10 @@ let
     set -euo pipefail
     export PATH="${pkgs.ffmpeg}/bin:$PATH"
     export HOME=/tmp
-    pip install --quiet --user faster-whisper
-    export PYTHONPATH="/app:$HOME/.local/lib/python3.12/site-packages:$PYTHONPATH"
-    python /app/server.py
+    export PIP_TARGET=/tmp/pip-packages
+    pip install --quiet faster-whisper
+    export PYTHONPATH="/app:$PIP_TARGET:''${PYTHONPATH:-}"
+    exec python /app/server.py
   '';
 in
 pkgs.dockerTools.buildImage {
@@ -32,6 +33,7 @@ pkgs.dockerTools.buildImage {
       pythonEnv
       pkgs.ffmpeg
       pkgs.cacert
+      pkgs.stdenv.cc.cc.lib
     ];
     pathsToLink = [
       "/bin"
@@ -52,6 +54,7 @@ pkgs.dockerTools.buildImage {
     };
     Env = [
       "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib"
       "WHISPER_MODEL=base"
       "WHISPER_HOST=0.0.0.0"
       "WHISPER_PORT=9002"


### PR DESCRIPTION
## Summary

- Use PIP_TARGET instead of --user for pip install
- Set LD_LIBRARY_PATH for libstdc++ access
- Add smoke-test-docker recipe to justfile

Closes #12