### PR TITLE
fix: correct type annotation for process_request

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,13 +34,27 @@ test:
     set -euo pipefail
     pytest src -v
 
-# Full CI pipeline
-CI:
+# Check formatting and lint (no modifications)
+check:
     #!/usr/bin/env bash
     set -euo pipefail
-    just format
-    just lint
-    just test
+    echo "==> Format check"
+    nix develop --quiet -c black --check src
+    nix develop --quiet -c ruff check src
+    echo "==> Type check"
+    nix develop --quiet -c mypy src
+
+# Run local CI (matches GitHub Actions)
+ci:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "==> Lint"
+    just check
+    echo "==> Test"
+    nix develop --quiet -c pytest src -v
+    echo "==> Build docker"
+    nix build .#docker-image --quiet
+    echo "CI passed!"
 
 # Build docker image
 build-docker tag='latest':

--- a/src/server.py
+++ b/src/server.py
@@ -11,14 +11,14 @@ import websockets
 from websockets.http11 import Request, Response
 
 if TYPE_CHECKING:
-    from websockets.asyncio.server import Server, ServerConnection
+    from websockets.asyncio.server import ServerConnection
 
 from config import Config, load_config
 from transcriber import Transcriber
 
 
 def process_request(
-    connection: Server,
+    connection: ServerConnection,
     request: Request,
 ) -> Response | None:
     """Process incoming WebSocket request.


### PR DESCRIPTION
## Summary
- Fixed type annotation on `process_request` function: `Server` → `ServerConnection`
- Removed unused `Server` import
- Added `just ci` recipe to run CI checks locally before pushing

## Test plan
- [x] `just ci` passes locally
- [ ] GitHub CI passes