### PR TITLE
ci: upload docker image as artifact

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,6 +52,13 @@ jobs:
       - name: Build Docker image
         run: nix build .#docker-image --quiet
 
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: result
+          retention-days: 7
+
   smoke-test:
     runs-on: ubuntu-latest
     needs: build-docker


### PR DESCRIPTION
Closes #28

## Summary
- Upload built docker image as GitHub Actions artifact
- 7 day retention
- Download from Actions tab after CI runs

## Test plan
- [ ] CI passes
- [ ] Artifact appears in Actions run