### PR TITLE
fix: remove VERSION commit from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,26 +91,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update VERSION file
+      - name: Set version and build Docker image
         run: |
           echo "${{ inputs.version }}" > VERSION
-          git add VERSION
-          if git diff --cached --quiet; then
-            echo "VERSION already set to ${{ inputs.version }}"
-          else
-            git commit -m "chore: bump version to ${{ inputs.version }}"
-            git push
-          fi
+          nix build .#docker-image
+          docker load < result
 
       - name: Create and push tag
         run: |
           git tag "v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
-
-      - name: Build Docker image
-        run: |
-          nix build .#docker-image
-          docker load < result
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -17,7 +17,6 @@ graph LR
 
     subgraph Release
         R[Manual Trigger]
-        V[Update VERSION]
         D[Tag + Docker + GitHub Release]
         S[Summary only]
     end
@@ -25,13 +24,11 @@ graph LR
     FB -->|push| PR
     PR -->|CI passes| M
     M -->|workflow_dispatch| R
-    R -->|dry_run=false| V
+    R -->|dry_run=false| D
     R -->|dry_run=true| S
-    V -->|commit + push| M
-    V --> D
 ```
 
-Feature branches trigger CI on PR. After merge to main, releases are triggered manually on main. With `dry_run=false`, the release workflow commits the VERSION bump back to main before creating the tag and artifacts. With `dry_run=true`, no changes are made - only a summary is printed.
+Feature branches trigger CI on PR. After merge to main, releases are triggered manually. With `dry_run=false`, the release workflow creates a git tag, pushes the Docker image, and creates a GitHub release. With `dry_run=true`, no changes are made - only a summary is printed.
 
 ## CI Workflow
 


### PR DESCRIPTION
## Summary
- Remove direct VERSION commit to main (blocked by branch protection)
- Set VERSION locally just for docker build during release
- Update CI/CD documentation diagram

## Test plan
- [ ] Run dry-run release to verify workflow
- [ ] Run actual release 0.1.1