### PR TITLE
fix: docker-compose for Tailscale access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
     image: ghcr.io/paolino/whisper-server:latest
     container_name: whisper-server
     restart: unless-stopped
-    ports:
-      - "${WHISPER_PORT:-9002}:9002"
+    network_mode: host
     environment:
-      - WHISPER_MODEL=${WHISPER_MODEL:-base}
+      - WHISPER_HOST=${WHISPER_HOST}  # Set to Tailscale IP for secure remote access
+      - WHISPER_PORT=${WHISPER_PORT:-9002}
+      - WHISPER_MODEL=${WHISPER_MODEL:-small}
       - WHISPER_DEVICE=${WHISPER_DEVICE:-auto}
       - WHISPER_COMPUTE_TYPE=${WHISPER_COMPUTE_TYPE:-auto}
-      - WHISPER_LANGUAGE=${WHISPER_LANGUAGE:-}
+      # WHISPER_LANGUAGE - set to language code (e.g., en, it) or omit for auto-detect
     volumes:
       - whisper-cache:/tmp/pip-packages
       - huggingface-cache:/tmp/.cache


### PR DESCRIPTION
## Summary
- Use `network_mode: host` for Tailscale compatibility
- Add `WHISPER_HOST` env var for binding to specific IP
- Remove empty `WHISPER_LANGUAGE` (caused errors)
- Default to `small` model (good speed/accuracy balance)

## Test plan
- [ ] Run with `WHISPER_HOST=<tailscale-ip>` and verify mobile access
- [ ] Verify service not exposed on public interfaces

Closes #44