### PR TITLE
Add HTTP /transcribe endpoint for batch transcription

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
           pythonEnv = pkgs.python3.withPackages (
             ps: with ps; [
               websockets
+              aiohttp
               numpy
               pydantic
               pydantic-settings

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -6,6 +6,7 @@ let
   pythonEnv = pkgs.python3.withPackages (
     ps: with ps; [
       websockets
+      aiohttp
       numpy
       pydantic
       pydantic-settings
@@ -52,6 +53,7 @@ pkgs.dockerTools.buildImage {
     WorkingDir = "/app";
     ExposedPorts = {
       "9002/tcp" = { };
+      "9003/tcp" = { };
     };
     Env = [
       "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -59,6 +61,7 @@ pkgs.dockerTools.buildImage {
       "WHISPER_MODEL=base"
       "WHISPER_HOST=0.0.0.0"
       "WHISPER_PORT=9002"
+      "WHISPER_HTTP_PORT=9003"
       "WHISPER_LLAMA_ENABLED=false"
     ];
     Labels = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -10,6 +10,7 @@ let
   pythonEnv = pkgs.python3.withPackages (
     ps: with ps; [
       websockets
+      aiohttp
       numpy
       pydantic
       pydantic-settings
@@ -58,7 +59,13 @@ in
     port = lib.mkOption {
       type = lib.types.port;
       default = 9002;
-      description = "Port to listen on.";
+      description = "WebSocket port to listen on.";
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 9003;
+      description = "HTTP port for /transcribe endpoint.";
     };
 
     model = lib.mkOption {
@@ -118,6 +125,7 @@ in
       environment = {
         WHISPER_HOST = cfg.host;
         WHISPER_PORT = toString cfg.port;
+        WHISPER_HTTP_PORT = toString cfg.httpPort;
         WHISPER_MODEL = cfg.model;
         WHISPER_DEVICE = cfg.device;
         WHISPER_COMPUTE_TYPE = cfg.computeType;
@@ -149,7 +157,10 @@ in
     };
 
     networking.firewall = lib.mkIf cfg.tailscale.enable {
-      interfaces.${cfg.tailscale.interface}.allowedTCPPorts = [ cfg.port ];
+      interfaces.${cfg.tailscale.interface}.allowedTCPPorts = [
+        cfg.port
+        cfg.httpPort
+      ];
     };
   };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "websockets>=12.0",
+    "aiohttp>=3.9",
     "numpy>=1.26",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ class Config(BaseSettings):
 
     host: str = "0.0.0.0"
     port: int = 9002
+    http_port: int = 9003
     model: str = "base"
     device: str = "auto"
     compute_type: str = "auto"

--- a/src/server.py
+++ b/src/server.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import websockets
+from aiohttp import web
 from websockets.http11 import Request, Response
 
 if TYPE_CHECKING:
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
 from config import Config, load_config
 from postprocessor import PostProcessor
 from transcriber import Transcriber
+
+SUPPORTED_AUDIO_EXTENSIONS = {".oga", ".ogg", ".wav", ".mp3", ".m4a"}
 
 
 def process_request(
@@ -150,8 +153,92 @@ class WhisperServer:
         }
         await websocket.send(json.dumps(response))
 
+    async def handle_transcribe(self, request: web.Request) -> web.Response:
+        """Handle HTTP POST /transcribe for batch transcription."""
+        try:
+            reader = await request.multipart()
+            field = await reader.next()
+
+            if field is None:
+                return web.json_response(
+                    {"error": "Missing 'audio' field in form data"},
+                    status=400,
+                )
+
+            # Ensure we have a body part, not a nested multipart reader
+            if not hasattr(field, "name") or field.name != "audio":
+                return web.json_response(
+                    {"error": "Missing 'audio' field in form data"},
+                    status=400,
+                )
+
+            filename = getattr(field, "filename", None) or "audio.bin"
+            extension = filename.lower().rsplit(".", 1)[-1] if "." in filename else ""
+
+            if f".{extension}" not in SUPPORTED_AUDIO_EXTENSIONS:
+                return web.json_response(
+                    {
+                        "error": f"Unsupported format '.{extension}'. "
+                        f"Supported: {', '.join(sorted(SUPPORTED_AUDIO_EXTENSIONS))}"
+                    },
+                    status=400,
+                )
+
+            audio_data = await field.read()  # type: ignore[union-attr]
+
+            if not audio_data:
+                return web.json_response(
+                    {"error": "Empty audio file"},
+                    status=400,
+                )
+
+            logger.info(
+                "HTTP transcribe: %s (%d bytes)",
+                filename,
+                len(audio_data),
+            )
+
+            transcript = await self.transcriber.transcribe_file(audio_data, filename)
+
+            if self.postprocessor.enabled:
+                loop = asyncio.get_event_loop()
+                transcript = await loop.run_in_executor(
+                    None,
+                    self.postprocessor.process,
+                    transcript,
+                    self.config.language,
+                )
+                logger.info("Post-processed: %s", transcript)
+
+            logger.info("Transcription: %s", transcript)
+
+            return web.json_response({"text": transcript})
+
+        except TimeoutError:
+            return web.json_response(
+                {"error": "Transcription timed out"},
+                status=504,
+            )
+        except ValueError as e:
+            return web.json_response(
+                {"error": str(e)},
+                status=400,
+            )
+        except Exception:
+            logger.exception("Error processing transcription request")
+            return web.json_response(
+                {"error": "Internal server error"},
+                status=500,
+            )
+
+    def _create_http_app(self) -> web.Application:
+        """Create the aiohttp application for HTTP endpoints."""
+        app = web.Application()
+        app.router.add_post("/transcribe", self.handle_transcribe)
+        return app
+
     async def run(self) -> None:
-        """Start the WebSocket server."""
+        """Start the WebSocket and HTTP servers."""
         logger.info("Loading Whisper model: %s", self.config.model)
         _ = self.transcriber.model  # Preload model
 
@@ -160,11 +247,24 @@ class WhisperServer:
             _ = self.postprocessor.model  # Preload model
 
         logger.info(
-            "Starting server on %s:%d",
+            "Starting WebSocket server on %s:%d",
             self.config.host,
             self.config.port,
         )
+        logger.info(
+            "Starting HTTP server on %s:%d",
+            self.config.host,
+            self.config.http_port,
+        )
 
+        # Start HTTP server
+        http_app = self._create_http_app()
+        http_runner = web.AppRunner(http_app)
+        await http_runner.setup()
+        http_site = web.TCPSite(http_runner, self.config.host, self.config.http_port)
+        await http_site.start()
+
+        # Start WebSocket server
         async with websockets.serve(
             self.handle_connection,
             self.config.host,

--- a/src/test_config.py
+++ b/src/test_config.py
@@ -8,6 +8,7 @@ def test_config_defaults() -> None:
     config = Config()
     assert config.host == "0.0.0.0"
     assert config.port == 9002
+    assert config.http_port == 9003
     assert config.model == "base"
     assert config.device == "auto"
     assert config.compute_type == "auto"

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import struct
+import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -55,6 +58,104 @@ class Transcriber:
         )
 
         return " ".join(segment.text.strip() for segment in segments)
+
+    async def transcribe_file(self, audio_data: bytes, filename: str) -> str:
+        """Transcribe audio from a file.
+
+        Uses ffmpeg to convert to PCM format if needed.
+
+        Args:
+            audio_data: Raw audio file bytes
+            filename: Original filename (used to determine format)
+
+        Returns:
+            Transcribed text
+        """
+        loop = asyncio.get_event_loop()
+        pcm_data = await loop.run_in_executor(
+            None,
+            self._convert_to_pcm,
+            audio_data,
+            filename,
+        )
+        return await loop.run_in_executor(None, self.transcribe, pcm_data)
+
+    def _convert_to_pcm(self, audio_data: bytes, filename: str) -> bytes:
+        """Convert audio file to raw PCM using ffmpeg.
+
+        Args:
+            audio_data: Raw audio file bytes
+            filename: Original filename (for format detection)
+
+        Returns:
+            Raw PCM data (16kHz, 16-bit signed LE, mono)
+        """
+        suffix = Path(filename).suffix.lower()
+
+        # If already PCM-compatible WAV, try direct processing
+        if suffix == ".wav":
+            try:
+                return self._extract_pcm_from_wav(audio_data)
+            except ValueError:
+                pass  # Fall through to ffmpeg conversion
+
+        # Use ffmpeg to convert to PCM
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-i",
+                "pipe:0",
+                "-f",
+                "s16le",
+                "-acodec",
+                "pcm_s16le",
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "pipe:1",
+            ],
+            input=audio_data,
+            capture_output=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            raise ValueError(f"ffmpeg conversion failed: {result.stderr.decode()}")
+
+        return result.stdout
+
+    def _extract_pcm_from_wav(self, wav_data: bytes) -> bytes:
+        """Extract PCM data from WAV file if format is compatible.
+
+        Args:
+            wav_data: WAV file bytes
+
+        Returns:
+            Raw PCM data
+
+        Raises:
+            ValueError: If WAV format is not compatible
+        """
+        if len(wav_data) < 44:
+            raise ValueError("WAV file too short")
+
+        # Parse WAV header
+        if wav_data[:4] != b"RIFF" or wav_data[8:12] != b"WAVE":
+            raise ValueError("Not a valid WAV file")
+
+        # Find data chunk
+        pos = 12
+        while pos < len(wav_data) - 8:
+            chunk_id = wav_data[pos : pos + 4]
+            chunk_size = struct.unpack("<I", wav_data[pos + 4 : pos + 8])[0]
+
+            if chunk_id == b"data":
+                return wav_data[pos + 8 : pos + 8 + chunk_size]
+
+            pos += 8 + chunk_size
+
+        raise ValueError("No data chunk found in WAV")
 
     def _wrap_pcm_as_wav(self, pcm_data: bytes) -> bytes:
         """Wrap raw PCM data in a WAV header."""


### PR DESCRIPTION
## Summary

- Add `POST /transcribe` endpoint for batch audio transcription
- Support formats: `.oga`, `.ogg`, `.wav`, `.mp3`, `.m4a`
- Use ffmpeg for audio conversion
- Add configurable `http_port` (default 9003)

Closes #48

## Test plan

- [x] Lint passes
- [x] Tests pass
- [x] Manual testing with curl